### PR TITLE
Fix AttributeError for newer StreamDeck PID constants

### DIFF
--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -203,7 +203,7 @@ class DeckManager:
                 return
             if not controller.deck.is_open():
                 return
-            
+
             log.info(f"Closing deck: {controller.deck.get_serial_number()}")
             controller.clear()
             controller.deck.close()
@@ -213,8 +213,8 @@ class DeckManager:
         devices = usb.core.find(find_all=True)
         for device in devices:
             try:
-                # Check if it's a StreamDeck
-                if device.idVendor == DeviceManager.USB_VID_ELGATO and device.idProduct in [
+                # Build list of supported device PIDs with defensive checks
+                supported_pids = [
                     DeviceManager.USB_PID_STREAMDECK_ORIGINAL,
                     DeviceManager.USB_PID_STREAMDECK_ORIGINAL_V2,
                     DeviceManager.USB_PID_STREAMDECK_MINI,
@@ -223,7 +223,20 @@ class DeckManager:
                     DeviceManager.USB_PID_STREAMDECK_PEDAL,
                     DeviceManager.USB_PID_STREAMDECK_PLUS,
                     DeviceManager.USB_PID_STREAMDECK_NEO
-                ]:
+                ]
+
+                # Add newer device PIDs only if they exist in the current library version
+                if hasattr(DeviceManager, 'USB_PID_STREAMDECK_MK2_SCISSOR'):
+                    supported_pids.append(DeviceManager.USB_PID_STREAMDECK_MK2_SCISSOR)
+                if hasattr(DeviceManager, 'USB_PID_STREAMDECK_MK2_MODULE'):
+                    supported_pids.append(DeviceManager.USB_PID_STREAMDECK_MK2_MODULE)
+                if hasattr(DeviceManager, 'USB_PID_STREAMDECK_MINI_MK2_MODULE'):
+                    supported_pids.append(DeviceManager.USB_PID_STREAMDECK_MINI_MK2_MODULE)
+                if hasattr(DeviceManager, 'USB_PID_STREAMDECK_XL_V2_MODULE'):
+                    supported_pids.append(DeviceManager.USB_PID_STREAMDECK_XL_V2_MODULE)
+
+                # Check if it's a StreamDeck
+                if device.idVendor == DeviceManager.USB_VID_ELGATO and device.idProduct in supported_pids:
                     # Reset deck
                     usb.util.dispose_resources(device)
                     device.reset()
@@ -300,5 +313,5 @@ class DetectResumeThread(threading.Thread):
             self.last_2 = time.time()
             if time.time() - self.last_1 >= 5 or time.time() - self.last_2 >= 5:
                 self.deck_manager.on_resumed()
-            
+
             time.sleep(2)


### PR DESCRIPTION
## Problem

The application was crashing on startup with an `AttributeError` when newer StreamDeck PID constants were referenced in the code but were not available in the installed version of the `python-elgato-streamdeck` library.

## Solution

This PR introduces `hasattr()` checks to verify the existence of PID constants before they are used. This approach:

- Makes device detection more robust
- Prevents crashes when using older library versions
- Maintains support for newer devices when the library is updated
- Unifies the device lists in `main.py` and `DeckManager.py`

## Changes

- Added defensive checks using `hasattr()` in both `main.py` and `src/backend/DeckManagement/DeckManager.py`
- Unified device detection logic across both files
- Ensures backward compatibility with older library versions

## Testing

The fix ensures that the application will start successfully regardless of the `python-elgato-streamdeck` library version, while still supporting all available devices for the installed version.

Fixes PID-23